### PR TITLE
feat: remove Node.js v6 and v8

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [6, 8, 10, 12, 14]
+        node-version: [10, 12, 14]
         os: [ubuntu-latest, windows-latest, macOS-latest]
     steps:
     - uses: actions/checkout@v2.3.2

--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
   "directories": {
     "test": "test"
   },
+  "engines": {
+    "node": "10 || 12 || >=14"
+  },
   "scripts": {
     "generate": "pegjs -o lib/parser.js src/wsplit.peg",
     "pretest": "npm run -s generate",


### PR DESCRIPTION
BREAKING CHANGE: Node.js v10 is now the minimum support version of
Node.js.